### PR TITLE
Fix Panic in Name Comparison

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "more-options"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2018"
 rust-version = "1.60"
 authors = ["Chris Martinez <chris.s.martinez@hotmail.com>"]

--- a/guide/src/getting-started.md
+++ b/guide/src/getting-started.md
@@ -5,7 +5,7 @@
 The simplest way to get started is to install the crate using the default features.
 
 ```bash
-cargo install more-options
+cargo add more-options
 ```
 
 ## Example

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -574,10 +574,12 @@ fn names_equal(name: Option<&str>, other_name: Option<&str>) -> bool {
 
     if matches_all || name == other_name {
         return true;
+    } else if other_name.is_none() {
+        return false;
     }
 
-    let name1 = name.clone().unwrap();
-    let name2 = other_name.clone().unwrap();
+    let name1 = name.unwrap();
+    let name2 = other_name.unwrap();
 
     (name1.len() == name2.len())
         && ((name1.to_uppercase() == name2.to_uppercase())


### PR DESCRIPTION
Corrects missing a check for `None` which comparison option configurations. Fixes #6.