### PR TITLE
Use ConfigurationSection to Configuration Conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,13 +38,13 @@ features = ["builder"]
 optional = true
 
 [dependencies.more-config]
-version = "2.0"
+version = "2.1"
 default-features = false
 features = ["binder"]
 optional = true
 
 [dev-dependencies]
-more-config = { version = "2.0", features = ["binder", "mem", "json"] }
+more-config = { version = "2.1", features = ["binder", "mem", "json"] }
 more-options = { path = ".", features = ["cfg"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "more-options"
-version = "3.0.1"
+version = "3.1.0"
 edition = "2018"
 rust-version = "1.60"
 authors = ["Chris Martinez <chris.s.martinez@hotmail.com>"]

--- a/src/cfg_ext.rs
+++ b/src/cfg_ext.rs
@@ -43,18 +43,18 @@ impl<TOptions> OptionsChangeTokenSource<TOptions> for ConfigurationChangeTokenSo
 /// Defines extension methods for the [`ServiceCollection`](di::ServiceCollection) struct.
 pub trait OptionsConfigurationServiceExtensions {
     /// Registers an options type that will have all of its associated services registered.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `configuration` - The [configuration](config::Configuration) applied to the options
     fn apply_config<T>(&mut self, configuration: Ref<dyn Configuration>) -> OptionsBuilder<T>
     where
         T: Default + DeserializeOwned + 'static;
 
     /// Registers an options type that will have all of its associated services registered.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `configuration` - The [configuration](config::Configuration) applied to the options
     /// * `key` - The key to the part of the [configuration](config::Configuration) applied to the options
     fn apply_config_at<T>(
@@ -148,6 +148,25 @@ mod tests {
     }
 
     #[test]
+    fn apply_config_should_bind_configuration_section_to_options() {
+        // arrange
+        let config = DefaultConfigurationBuilder::new()
+            .add_in_memory(&[("Test:Enabled", "true")])
+            .build()
+            .unwrap();
+        let provider = ServiceCollection::new()
+            .apply_config::<TestOptions>(config.section("Test").as_config().into())
+            .build_provider()
+            .unwrap();
+
+        // act
+        let options = provider.get_required::<dyn Options<TestOptions>>();
+
+        // assert
+        assert!(options.value().enabled);
+    }
+
+    #[test]
     fn apply_config_at_should_bind_configuration_to_options() {
         // arrange
         let config = Ref::from(
@@ -192,7 +211,9 @@ mod tests {
             .unwrap();
 
         let token = config.reload_token();
-        let original = provider.get_required::<dyn OptionsMonitor<TestOptions>>().current_value();
+        let original = provider
+            .get_required::<dyn OptionsMonitor<TestOptions>>()
+            .current_value();
         let state = Arc::new((Mutex::new(false), Condvar::new()));
         let _unused = token.register(
             Box::new(|s| {
@@ -220,7 +241,9 @@ mod tests {
         }
 
         // act
-        let current = provider.get_required::<dyn OptionsMonitor<TestOptions>>().current_value();
+        let current = provider
+            .get_required::<dyn OptionsMonitor<TestOptions>>()
+            .current_value();
 
         // assert
         if path.exists() {


### PR DESCRIPTION
- Bumps minor version to support `ConfigurationSection::as_config` for data binding
- Add test case for binding `ConfigurationSection`