### PR TITLE
Add Send + Sync to the async feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "more-options"
-version = "3.2.0"
+version = "3.3.0"
 edition = "2018"
 rust-version = "1.60"
 authors = ["Chris Martinez <chris.s.martinez@hotmail.com>"]
@@ -25,11 +25,12 @@ doctest = false
 [features]
 di = ["more-di"]
 cfg = ["di", "more-config", "serde"]
-async = ["more-di?/async"]
+async = ["more-di?/async", "maybe-impl"]
 
 [dependencies]
 more-changetoken = "2.0"
 serde = { version = "1.0", optional = true }
+maybe-impl = { version = "0.1.0", optional = true }
 
 [dependencies.more-di]
 version = "3.1"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,9 +1,10 @@
-use crate::Ref;
+use crate::{Ref, Value};
 use std::collections::HashMap;
 use std::sync::Mutex;
 
 /// Defines the behavior of an [`Options`](crate::Options) monitor cache.
-pub trait OptionsMonitorCache<T> {
+#[cfg_attr(feature = "async", maybe_impl::traits(Send, Sync))]
+pub trait OptionsMonitorCache<T: Value> {
     /// Gets or adds options with the specified name.
     ///
     /// # Arguments
@@ -44,7 +45,10 @@ impl<T> Default for OptionsCache<T> {
     }
 }
 
-impl<T> OptionsMonitorCache<T> for OptionsCache<T> {
+unsafe impl<T: Send + Sync> Send for OptionsCache<T> {}
+unsafe impl<T: Send + Sync> Sync for OptionsCache<T> {}
+
+impl<T: Value> OptionsMonitorCache<T> for OptionsCache<T> {
     fn get_or_add(&self, name: Option<&str>, create_options: &dyn Fn(Option<&str>) -> T) -> Ref<T> {
         let key = name.unwrap_or_default().to_string();
         self.cache

--- a/src/di_ext.rs
+++ b/src/di_ext.rs
@@ -7,14 +7,14 @@ use di::{
 /// Defines extension methods for the [`ServiceCollection`](di::ServiceCollection) struct.
 pub trait OptionsServiceExtensions {
     /// Registers an options type that will have all of its associated services registered.
-    fn add_options<T: Default + 'static>(&mut self) -> OptionsBuilder<T>;
+    fn add_options<T: Value + Default + 'static>(&mut self) -> OptionsBuilder<T>;
 
     /// Registers an options type that will have all of its associated services registered.
     ///
     /// # Arguments
     ///
     /// * `name` - The name associated with the options
-    fn add_named_options<T: Default + 'static>(
+    fn add_named_options<T: Value + Default + 'static>(
         &mut self,
         name: impl AsRef<str>,
     ) -> OptionsBuilder<T>;
@@ -26,6 +26,7 @@ pub trait OptionsServiceExtensions {
     /// * `factory` - The function used to create the associated options factory
     fn add_options_with<T, F>(&mut self, factory: F) -> OptionsBuilder<T>
     where
+        T: Value,
         F: Fn(&ServiceProvider) -> Ref<dyn OptionsFactory<T>> + 'static;
 
     /// Registers an options type that will have all of its associated services registered.
@@ -40,6 +41,7 @@ pub trait OptionsServiceExtensions {
         factory: F,
     ) -> OptionsBuilder<T>
     where
+        T: Value,
         F: Fn(&ServiceProvider) -> Ref<dyn OptionsFactory<T>> + 'static;
 
     /// Registers an action used to initialize a particular type of configuration options.
@@ -47,8 +49,9 @@ pub trait OptionsServiceExtensions {
     /// # Arguments
     ///
     /// * `setup` - The setup action used to configure options.
-    fn configure_options<T: Default + 'static, F>(&mut self, setup: F) -> &mut Self
+    fn configure_options<T, F>(&mut self, setup: F) -> &mut Self
     where
+        T: Value + Default + 'static,
         F: Fn(&mut T) + 'static;
 
     /// Registers an action used to initialize a particular type of configuration options.
@@ -57,12 +60,9 @@ pub trait OptionsServiceExtensions {
     ///
     /// * `name` - The name associated with the options
     /// * `setup` - The setup action used to configure options
-    fn configure_named_options<T: Default + 'static, F>(
-        &mut self,
-        name: impl AsRef<str>,
-        setup: F,
-    ) -> &mut Self
+    fn configure_named_options<T, F>(&mut self, name: impl AsRef<str>, setup: F) -> &mut Self
     where
+        T: Value + Default + 'static,
         F: Fn(&mut T) + 'static;
 
     /// Registers an action used to initialize a particular type of configuration options.
@@ -70,8 +70,9 @@ pub trait OptionsServiceExtensions {
     /// # Arguments
     ///
     /// * `setup` - The setup action used to configure options
-    fn post_configure_options<T: Default + 'static, F>(&mut self, setup: F) -> &mut Self
+    fn post_configure_options<T, F>(&mut self, setup: F) -> &mut Self
     where
+        T: Value + Default + 'static,
         F: Fn(&mut T) + 'static;
 
     /// Registers an action used to initialize a particular type of configuration options.
@@ -80,16 +81,13 @@ pub trait OptionsServiceExtensions {
     ///
     /// * `name` - The name associated with the options
     /// * `setup` - The setup action used to configure options
-    fn post_configure_named_options<T: Default + 'static, F>(
-        &mut self,
-        name: impl AsRef<str>,
-        setup: F,
-    ) -> &mut Self
+    fn post_configure_named_options<T, F>(&mut self, name: impl AsRef<str>, setup: F) -> &mut Self
     where
+        T: Value + Default + 'static,
         F: Fn(&mut T) + 'static;
 }
 
-fn _add_options<'a, T>(
+fn _add_options<'a, T: Value>(
     services: &'a mut ServiceCollection,
     name: Option<&str>,
     descriptor: ServiceDescriptor,
@@ -137,7 +135,7 @@ fn _add_options<'a, T>(
 }
 
 impl OptionsServiceExtensions for ServiceCollection {
-    fn add_options<T: Default + 'static>(&mut self) -> OptionsBuilder<T> {
+    fn add_options<T: Value + Default + 'static>(&mut self) -> OptionsBuilder<T> {
         let descriptor = transient::<dyn OptionsFactory<T>, DefaultOptionsFactory<T>>()
             .depends_on(zero_or_more::<dyn ConfigureOptions<T>>())
             .depends_on(zero_or_more::<dyn PostConfigureOptions<T>>())
@@ -153,7 +151,7 @@ impl OptionsServiceExtensions for ServiceCollection {
         _add_options(self, None, descriptor)
     }
 
-    fn add_named_options<T: Default + 'static>(
+    fn add_named_options<T: Value + Default + 'static>(
         &mut self,
         name: impl AsRef<str>,
     ) -> OptionsBuilder<T> {
@@ -174,6 +172,7 @@ impl OptionsServiceExtensions for ServiceCollection {
 
     fn add_options_with<T, F>(&mut self, factory: F) -> OptionsBuilder<T>
     where
+        T: Value,
         F: Fn(&ServiceProvider) -> Ref<dyn OptionsFactory<T>> + 'static,
     {
         _add_options(self, None, transient_factory(factory))
@@ -185,42 +184,39 @@ impl OptionsServiceExtensions for ServiceCollection {
         factory: F,
     ) -> OptionsBuilder<T>
     where
+        T: Value,
         F: Fn(&ServiceProvider) -> Ref<dyn OptionsFactory<T>> + 'static,
     {
         _add_options(self, Some(name.as_ref()), transient_factory(factory))
     }
 
-    fn configure_options<T: Default + 'static, F>(&mut self, setup: F) -> &mut Self
+    fn configure_options<T, F>(&mut self, setup: F) -> &mut Self
     where
+        T: Value + Default + 'static,
         F: Fn(&mut T) + 'static,
     {
         self.add_options().configure(setup).into()
     }
 
-    fn configure_named_options<T: Default + 'static, F>(
-        &mut self,
-        name: impl AsRef<str>,
-        setup: F,
-    ) -> &mut Self
+    fn configure_named_options<T, F>(&mut self, name: impl AsRef<str>, setup: F) -> &mut Self
     where
+        T: Value + Default + 'static,
         F: Fn(&mut T) + 'static,
     {
         self.add_named_options(name).configure(setup).into()
     }
 
-    fn post_configure_options<T: Default + 'static, F>(&mut self, setup: F) -> &mut Self
+    fn post_configure_options<T, F>(&mut self, setup: F) -> &mut Self
     where
+        T: Value + Default + 'static,
         F: Fn(&mut T) + 'static,
     {
         self.add_options().post_configure(setup).into()
     }
 
-    fn post_configure_named_options<T: Default + 'static, F>(
-        &mut self,
-        name: impl AsRef<str>,
-        setup: F,
-    ) -> &mut Self
+    fn post_configure_named_options<T, F>(&mut self, name: impl AsRef<str>, setup: F) -> &mut Self
     where
+        T: Value + Default + 'static,
         F: Fn(&mut T) + 'static,
     {
         self.add_named_options(name).configure(setup).into()

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -1,7 +1,8 @@
 use crate::*;
 
 /// Defines the behavior of an object that creates configuration [`Options`](crate::Options).
-pub trait OptionsFactory<T> {
+#[cfg_attr(feature = "async", maybe_impl::traits(Send, Sync))]
+pub trait OptionsFactory<T: Value> {
     /// Creates and returns new configuration options.
     ///
     /// # Arguments
@@ -12,13 +13,16 @@ pub trait OptionsFactory<T> {
 
 /// Represents the default factory used to create configuration [`Options`](crate::Options).
 #[derive(Default)]
-pub struct DefaultOptionsFactory<T: Default> {
+pub struct DefaultOptionsFactory<T: Value + Default> {
     configurations: Vec<Ref<dyn ConfigureOptions<T>>>,
     post_configurations: Vec<Ref<dyn PostConfigureOptions<T>>>,
     validations: Vec<Ref<dyn ValidateOptions<T>>>,
 }
 
-impl<T: Default> DefaultOptionsFactory<T> {
+unsafe impl<T: Send + Sync + Default> Send for DefaultOptionsFactory<T> {}
+unsafe impl<T: Send + Sync + Default> Sync for DefaultOptionsFactory<T> {}
+
+impl<T: Value + Default> DefaultOptionsFactory<T> {
     /// Initializes a new options factory.
     ///
     /// # Arguments
@@ -39,7 +43,7 @@ impl<T: Default> DefaultOptionsFactory<T> {
     }
 }
 
-impl<T: Default> OptionsFactory<T> for DefaultOptionsFactory<T> {
+impl<T: Value + Default> OptionsFactory<T> for DefaultOptionsFactory<T> {
     fn create(&self, name: Option<&str>) -> Result<T, ValidateOptionsResult> {
         let mut options = Default::default();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,23 @@ pub type Ref<T> = std::sync::Arc<T>;
 #[cfg(all(feature = "di", feature = "async"))]
 pub type Ref<T> = di::Ref<T>;
 
+// trait aliases are unstable so define a custom
+// marker that can bridge the gap
+//
+// REF: https://github.com/rust-lang/rust/issues/41517
+
+#[cfg(not(feature = "async"))]
+pub trait Value: Sized {}
+
+#[cfg(not(feature = "async"))]
+impl<T> Value for T {}
+
+#[cfg(feature = "async")]
+pub trait Value: Sized + Send + Sync {}
+
+#[cfg(feature = "async")]
+impl<T: Send + Sync> Value for T {}
+
 mod cache;
 mod configure;
 mod factory;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,12 +1,14 @@
-use crate::{Options, OptionsCache, OptionsFactory, OptionsMonitorCache, OptionsSnapshot, Ref};
+use crate::{
+    Options, OptionsCache, OptionsFactory, OptionsMonitorCache, OptionsSnapshot, Ref, Value,
+};
 
 /// Represents an object that manages [`Options`](crate::Options) and [option snapshots](crate::OptionsSnapshot).
-pub struct OptionsManager<T> {
+pub struct OptionsManager<T: Value> {
     factory: Ref<dyn OptionsFactory<T>>,
     cache: OptionsCache<T>,
 }
 
-impl<T> OptionsManager<T> {
+impl<T: Value> OptionsManager<T> {
     /// Initializes a new options manager.
     ///
     /// # Arguments
@@ -20,13 +22,16 @@ impl<T> OptionsManager<T> {
     }
 }
 
-impl<T> Options<T> for OptionsManager<T> {
+unsafe impl<T: Send + Sync> Send for OptionsManager<T> {}
+unsafe impl<T: Send + Sync> Sync for OptionsManager<T> {}
+
+impl<T: Value> Options<T> for OptionsManager<T> {
     fn value(&self) -> Ref<T> {
         self.get(None)
     }
 }
 
-impl<T> OptionsSnapshot<T> for OptionsManager<T> {
+impl<T: Value> OptionsSnapshot<T> for OptionsManager<T> {
     fn get(&self, name: Option<&str>) -> Ref<T> {
         self.cache
             .get_or_add(name, &|n| self.factory.create(n).unwrap())

--- a/src/option.rs
+++ b/src/option.rs
@@ -1,7 +1,8 @@
-use crate::Ref;
+use crate::{Ref, Value};
 
 /// Defines the behavior to retrieve configured options.
-pub trait Options<T> {
+#[cfg_attr(feature = "async", maybe_impl::traits(Send, Sync))]
+pub trait Options<T: Value> {
     /// Gets the configured value.
     fn value(&self) -> Ref<T>;
 }
@@ -11,14 +12,17 @@ pub trait Options<T> {
 /// # Arguments
 ///
 /// * `options` - The options value to wrap.
-pub fn create<T>(options: T) -> impl Options<T> {
+pub fn create<T: Value>(options: T) -> impl Options<T> {
     OptionsWrapper(Ref::new(options))
 }
 
-struct OptionsWrapper<T>(Ref<T>);
+struct OptionsWrapper<T: Value>(Ref<T>);
 
-impl<T> Options<T> for OptionsWrapper<T> {
+impl<T: Value> Options<T> for OptionsWrapper<T> {
     fn value(&self) -> Ref<T> {
         self.0.clone()
     }
 }
+
+unsafe impl<T: Send + Sync> Send for OptionsWrapper<T> {}
+unsafe impl<T: Send + Sync> Sync for OptionsWrapper<T> {}

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,7 +1,8 @@
-use crate::Ref;
+use crate::{Ref, Value};
 
 /// Defines the behavior for a snapshot of configuration [`Options`](crate::Options).
-pub trait OptionsSnapshot<T> {
+#[cfg_attr(feature = "async", maybe_impl::traits(Send, Sync))]
+pub trait OptionsSnapshot<T: Value> {
     /// Gets the configuration options with the specified name.
     /// 
     /// # Arguments

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,7 +1,9 @@
+use crate::Value;
 use tokens::ChangeToken;
 
 /// Used to fetch [`ChangeToken`](tokens::ChangeToken) used for tracking options changes.
-pub trait OptionsChangeTokenSource<TOptions> {
+#[cfg_attr(feature = "async", maybe_impl::traits(Send, Sync))]
+pub trait OptionsChangeTokenSource<T: Value> {
     /// Creates and returns a [`ChangeToken`](tokens::ChangeToken) which can be
     /// used to register a change notification callback.
     fn token(&self) -> Box<dyn ChangeToken>;


### PR DESCRIPTION
Adds the `Send` and `Sync` traits for use in asynchronous contexts when the **async** feature is enabled.